### PR TITLE
First version of JSON path parameter implemetation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ Send JSON data from a URL to datadog.
 	export PERL5LIB=`pwd`
 	cd ..
 
-	./json2dog health_url statsd_base
+	./json2dog health_url statsd_base Jmes_path
 
 where
 
 * `health_url` is a URL to a JSON end point that returns stats we should graph
 * `statsd_base` is the start of the metric name that should be sent to datadog
+* `Jmes_path` is Json XPath like string that is passed to extract specific parameters from JSON string. if no string is passed the default Xpath string value is set to @(root) which passes the entire JSON string(http://jmespath.org/tutorial.html)
 
 Options can be set by setting environment variables:
 
@@ -37,7 +38,7 @@ Options can be set by setting environment variables:
 	# log to a file
 	export JSON2DOG_LOG=/var/log/json2dog.log
 
-	./json2dog health_url statsd_base
+	./json2dog health_url statsd_base Jmes_path
 
 Other options are used by the [init scripts](init.d/) and are documented [here](init.d/).
 
@@ -49,6 +50,7 @@ Other options are used by the [init scripts](init.d/) and are documented [here](
 * Perl module IO::Handle (core module)
 * Perl module IO::Socket::SSL
 * Perl module LWP::UserAgent
+* Perl module Jmespath
 
 The two standard Perl modules mentioned above can be installed my running
 [`prereq.sh`](prereq.sh).
@@ -66,3 +68,4 @@ You may find the [CHANGELOG](CHANGELOG.md) helpful.
 ## Authors <a name="authors"></a>
 
 * Christopher Hicks <chicks@telmate.com>
+

--- a/json2dog
+++ b/json2dog
@@ -9,6 +9,8 @@ use Data::Dumper;
 use LWP::UserAgent;
 use JSON;
 use IO::Handle;
+use Jmespath;
+use Data::Compare;
 
 use DataDog::DogStatsd;
 
@@ -23,7 +25,8 @@ my $use_curl = 0; # true if curl is better than LWP
 #print "use_curl = $use_curl\n";
 
 # read command line arguments
-my ($health_url,$statsd_base) = @ARGV;
+my ($health_url,$statsd_base,$json_path) = @ARGV;
+$json_path = $json_path || "@";
 
 daemonize() unless $debug;
 
@@ -70,15 +73,30 @@ while (1) {
 	my $health_resp = $json->decode($raw_html);
 	error(Dumper($health_resp)) if $debug > 1;
 
-	foreach my $key (keys %$health_resp) {
-		my $value = $health_resp->{$key};
+        my $result_object = Jmespath->search($json_path, $health_resp);
+        my $ref_type = $json->decode($result_object); #to check if it is ARRAY or HASH type, which denotes that JSON is not nested and should use the JSON response as it is and search for number in values.
+        if (ref($ref_type) eq "HASH"){
+	    foreach my $key (keys %$health_resp) {
+	        my $value = $health_resp->{$key};
 		if ($value =~ /^[0-9.]+$/) { # only numbers
 			my $metric_label = $statsd_base . '.' . $key;
 			error("$metric_label -> $value") if $debug;
 			$dogstatsd->gauge( $metric_label, $value);
 			$stats_sent++;
 		}
-	}
+	    }
+        } else {
+           # Using substring to pull the JSON key to use for metric_label
+           #my $path_key = (index $json_path, '?') + 1;
+           #my $path_condition = (index $json_path, '='); #Assuming we would most of the time try to pull stats based on the eqal condition
+           my $key = substr $json_path, (index $json_path, '?') + 1 , (((index $json_path, '='))-((index $json_path, '?') + 1));
+           my $value = Jmespath->search($json_path, $health_resp);
+           my $metric_label = $statsd_base . '.' . $key;
+           error("$metric_label -> $value") if $debug; 
+           $dogstatsd->gauge( $metric_label, $value);
+           $stats_sent++;
+           #to:do would have to pick the ip to make sure the stats are specific to hostnames or ips.
+        }
 
 	timed_log($stats_sent);
 
@@ -199,3 +217,4 @@ sub daemonize {
 		close($pid_fh) or die "couldn't close(>$pid_file): $!";
 	}
 }
+

--- a/json2dog
+++ b/json2dog
@@ -10,7 +10,6 @@ use LWP::UserAgent;
 use JSON;
 use IO::Handle;
 use Jmespath;
-use Data::Compare;
 
 use DataDog::DogStatsd;
 
@@ -74,6 +73,10 @@ while (1) {
 	error(Dumper($health_resp)) if $debug > 1;
 
         my $result_object = Jmespath->search($json_path, $health_resp);
+        eval { $json->decode($result_object); };
+        if ($@){
+           die "Input parameter error, please verify the Json XPATH variable used";
+        } 
         my $ref_type = $json->decode($result_object); #to check if it is ARRAY or HASH type, which denotes that JSON is not nested and should use the JSON response as it is and search for number in values.
         if (ref($ref_type) eq "HASH"){
 	    foreach my $key (keys %$health_resp) {
@@ -86,16 +89,17 @@ while (1) {
 		}
 	    }
         } else {
-           # Using substring to pull the JSON key to use for metric_label
-           #my $path_key = (index $json_path, '?') + 1;
-           #my $path_condition = (index $json_path, '='); #Assuming we would most of the time try to pull stats based on the eqal condition
-           my $key = substr $json_path, (index $json_path, '?') + 1 , (((index $json_path, '='))-((index $json_path, '?') + 1));
+           my $key;
+           if($json_path =~ /\?(.*)==/){
+             $key = $1;
+           } else {
+             $key = "status"; #Default name for key in case regex fails.
+           }
            my $value = Jmespath->search($json_path, $health_resp);
            my $metric_label = $statsd_base . '.' . $key;
-           error("$metric_label -> $value") if $debug; 
+           error("$metric_label -> $value") if $debug;
            $dogstatsd->gauge( $metric_label, $value);
            $stats_sent++;
-           #to:do would have to pick the ip to make sure the stats are specific to hostnames or ips.
         }
 
 	timed_log($stats_sent);
@@ -217,4 +221,3 @@ sub daemonize {
 		close($pid_fh) or die "couldn't close(>$pid_file): $!";
 	}
 }
-

--- a/json2dog
+++ b/json2dog
@@ -72,12 +72,8 @@ while (1) {
 	my $health_resp = $json->decode($raw_html);
 	error(Dumper($health_resp)) if $debug > 1;
 
-        my $result_object = Jmespath->search($json_path, $health_resp);
-        eval { $json->decode($result_object); };
-        if ($@){
-           die "Input parameter error, please verify the Json XPATH variable used";
-        } 
-        my $ref_type = $json->decode($result_object); #to check if it is ARRAY or HASH type, which denotes that JSON is not nested and should use the JSON response as it is and search for number in values.
+        my $ref_type = Jmespath::Parser->new->parse( $json_path )->search( $health_resp ) or die "Input parameter error, please verify the Json XPATH parameter used.";
+
         if (ref($ref_type) eq "HASH"){
 	    foreach my $key (keys %$health_resp) {
 	        my $value = $health_resp->{$key};
@@ -221,3 +217,4 @@ sub daemonize {
 		close($pid_fh) or die "couldn't close(>$pid_file): $!";
 	}
 }
+


### PR DESCRIPTION
Adding a new parameter to @ARGV to pick JSON path to pull specific parameters from JSON.
if no parameter is provided for path, then the variable $json_path is assigned with "@", which is going to return the entire JSON in JMESpath(Perl module to get JSON path working). 